### PR TITLE
Fix payment pending bug

### DIFF
--- a/woocommerce-gateway-brainblocks/woocommerce-gateway-brainblocks.php
+++ b/woocommerce-gateway-brainblocks/woocommerce-gateway-brainblocks.php
@@ -211,11 +211,11 @@ function wc_brainblocks_gateway_init() {
                 );
             }
 			
-			// Mark as on-hold (we're awaiting the payment)
-			$order->update_status('processing');
+			// Mark order status completed
+			$order->payment_complete();
 			
-			// Reduce stock levels
-			$order->reduce_order_stock();
+			// Reduce stock levels 
+			//$order->reduce_order_stock(); // <-- Pretty sure $order->payment_complete() handles this
 			
 			// Remove cart
 			WC()->cart->empty_cart();


### PR DESCRIPTION
Prior to this update, completed payments would be left as "Payment Pending".

In my tests, this update instead sets the status to "Processing" on a virtual and downloadable product, this is not the exact intended behaviour.

`$order->payment_complete();` is supposed to figure out the correct status on its own - which should be "Processing" if there are physical goods to ship (or some other admin action required), or "Completed" if not.

There might be more work required to figure out if this remaining issue is to do with the rest of my WC setup, or with the plugin code. I think it's likely my WC setup.